### PR TITLE
Add or fix support for sort$, skip$ and limit$

### DIFF
--- a/lib/mysql-store.js
+++ b/lib/mysql-store.js
@@ -487,12 +487,16 @@ var metaquery = function(qent,q) {
 
   if( q.sort$ ) {
     for( var sf in q.sort$ ) break;
-    var sd = q.sort$[sf] < 0 ? 'ASC' : 'DESC';
+    var sd = q.sort$[sf] < 0 ? 'DESC' : 'ASC';
     mq.push('ORDER BY '+sf+' '+sd);
   }
 
   if( q.limit$ ) {
-    mq.push('LIMIT '+q.limit$);
+    mq.push('LIMIT ' + q.limit$);
+  }
+
+  if( q.skip$ ) {
+    mq.push('OFFSET ' + q.skip$);
   }
 
   return mq;

--- a/lib/mysql-store.js
+++ b/lib/mysql-store.js
@@ -492,11 +492,11 @@ var metaquery = function(qent,q) {
   }
 
   if( q.limit$ ) {
-    mq.push('LIMIT ' + q.limit$);
+    mq.push('LIMIT ' + (Number(q.limit$)||0));
   }
 
   if( q.skip$ ) {
-    mq.push('OFFSET ' + q.skip$);
+    mq.push('OFFSET ' + (Number(q.skip$)||0));
   }
 
   return mq;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eyes": "*",
     "gex": "*",
     "mocha": "^2.0.0",
-    "seneca-store-test": "^0.2.2",
+    "seneca-store-test":  "git://github.com/paolochiodi/seneca-store-test.git",
     "vows": "*"
   }
 }

--- a/test/mysql.ext.test.js
+++ b/test/mysql.ext.test.js
@@ -112,31 +112,6 @@ exports.test = function(si, cb) {
       }))
     },
 
-    // test limit$
-    listwithlimit: function(cb) {
-      console.log('listwithlimit');
-      scratch.foo2.list$({limit$:1}, verify(cb, function(res){
-        assert.equal( 1, res.length)
-      }))
-    },
-
-    // test sort$
-    listwithsort1: function(cb) {
-      console.log('listwithsort1');
-      scratch.foo2.list$({sort$:{'p1':-1}}, verify(cb, function(res){
-        assert.equal( 2, res.length)
-        assert.equal('v2',res[0].p1)
-      }))
-    },
-
-    listwithsort2: function(cb) {
-      console.log('listwithsort2');
-      scratch.foo2.list$({sort$:{'p1':1}}, verify(cb, function(res){
-        assert.equal( 2, res.length)
-        assert.equal('v3',res[0].p1)
-      }))
-    },
-
     remove1: function(cb) {
       console.log('remove1');
       scratch.foo2.remove$( {id:scratch.foo2.id}, verify(cb, function(err){

--- a/test/mysql.test.js
+++ b/test/mysql.test.js
@@ -45,6 +45,16 @@ describe('mysql', function () {
     shared.basictest(si, done);
   });
 
+  it('sort', function(done){
+    testcount++;
+    shared.sorttest(si,done);
+  });
+
+  it('limits', function(done){
+    testcount++;
+    shared.limitstest(si,done);
+  });
+
   it('extra', function (done) {
     testcount++;
     extra.test(si, done);


### PR DESCRIPTION
**WARNING: this should be considered braking change and properly advertised.**
The sort$ method was bugged and was applying opposite order. Now it follows documentation and other stores.

This also use improved seneca-store-test not merged into master at the moment.
